### PR TITLE
Do not wrap handler if newrelic.Application is nil

### DIFF
--- a/newrelicutil.go
+++ b/newrelicutil.go
@@ -34,6 +34,9 @@ func WithTransaction(ctx context.Context, txn newrelic.Transaction) context.Cont
 // WrapHandler return the given http handler that is wrapped to New Relic Transaction.
 // Current New Relic Transaction is placed in the context.
 func WrapHandler(app newrelic.Application, name string, handler http.Handler) http.Handler {
+	if app == nil {
+		return handler
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		txn := app.StartTransaction(name, w, r)
 		defer txn.End()

--- a/newrelicutil_test.go
+++ b/newrelicutil_test.go
@@ -33,6 +33,17 @@ func TestWrapHandler(t *testing.T) {
 	wh.ServeHTTP(httptest.NewRecorder(), req)
 }
 
+func TestWrapHandler_NilApp(t *testing.T) {
+	h := http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		assert.Nil(t, newrelicutil.Transaction(r.Context()))
+	})
+	wh := newrelicutil.WrapHandler(nil, "foo", h)
+	req, _ := http.NewRequest("GET", "/", nil)
+	assert.NotPanics(t, func() {
+		wh.ServeHTTP(httptest.NewRecorder(), req)
+	})
+}
+
 func TestSegment(t *testing.T) {
 	want := &newrelic.Segment{}
 	have := newrelicutil.Segment(context.Background())


### PR DESCRIPTION
NewRelic is not required for service business logic.
So I have to log an error from `newrelic.NewApplication(config)` and use `nil` nrApp.
And I have to check that in my service:
```
if nrApp != nil {
	nrgorilla.InstrumentRoutes(router, nrApp)
}
```